### PR TITLE
chore: remove default features from `ed25519-dalek`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slipped10"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Ngo Iok Ui <wusyong9104@gmail.com>", "dj8yf0μl"]
 edition = "2021"
 description = "SLIP-0010 : ed25519 private key derivation from master private key"
@@ -13,7 +13,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ed25519-dalek = "2"
+ed25519-dalek = { version = "2", default-features = false }
 hmac = { version = "0.9", default-features = false }
 sha2 = { version = "0.9", default-features = false }
 


### PR DESCRIPTION
go from

```bash
ed25519-dalek v2.1.1
├── ed25519-dalek feature "alloc"
│   └── ed25519-dalek feature "std"
│       └── ed25519-dalek feature "default"
│           └── slipped10 v0.4.5 (/home/user/Documents/code/slipped10)
│               └── slipped10 feature "default" (command-line)
├── ed25519-dalek feature "default" (*)
├── ed25519-dalek feature "fast"
│   └── ed25519-dalek feature "default" (*)
├── ed25519-dalek feature "std" (*)
└── ed25519-dalek feature "zeroize"
    ├── ed25519-dalek feature "alloc" (*)
    └── ed25519-dalek feature "default" (*)
```

to

```bash
ed25519-dalek v2.1.1
└── slipped10 v0.4.6 (/home/user/Documents/code/slipped10)
    └── slipped10 feature "default" (command-line)
```


